### PR TITLE
update: Update ProductSchema and Add ProductUses Validation

### DIFF
--- a/src/validators/product.validators.ts
+++ b/src/validators/product.validators.ts
@@ -1,9 +1,33 @@
 import { z } from "zod";
-import { ProductCategory, ProductStatus } from "@prisma/client";
+
+// Define enums manually
+export enum ProductCategory {
+  MENS = "MENS",
+  WOMENS = "WOMENS",
+  KIDS = "KIDS",
+  OTHER = "OTHER",
+}
+
+export enum ProductStatus {
+  PENDING = "PENDING",
+  APPROVED = "APPROVED",
+  REJECTED = "REJECTED",
+}
+
+export enum ProductUses {
+  CASUAL = "CASUAL",
+  DATES = "DATES",
+  PARTIES = "PARTIES",
+  OFFICE = "OFFICE",
+  TRAVEL = "TRAVEL",
+  SPORTS = "SPORTS",
+  FORMALS = "FORMALS",
+}
 
 // Enum Validators
 export const productCategorySchema = z.nativeEnum(ProductCategory);
 export const productStatusSchema = z.nativeEnum(ProductStatus);
+export const productUsesSchema = z.nativeEnum(ProductUses);
 
 // Product Schema
 export const ProductSchema = z.object({
@@ -16,9 +40,10 @@ export const ProductSchema = z.object({
   stock: z.number().int().min(0, "Stock cannot be negative"),
   status: productStatusSchema.default(ProductStatus.PENDING),
   sellerId: z.string().uuid(),
+  productUses: z.array(productUsesSchema).default([]),
   bulkUpload: z.string().optional(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 // ProductDetails Schema
@@ -132,8 +157,10 @@ export const reviewSchema = z.object({
 export const querySchema = z.object({
   page: z.string().optional(),
   limit: z.string().optional(),
-  category: z.nativeEnum(ProductCategory).optional(),
-  status: z.nativeEnum(ProductStatus).optional(),
+  category: z
+    .enum([ProductCategory.MENS, ProductCategory.WOMENS, ProductCategory.KIDS, ProductCategory.OTHER])
+    .optional(),
+  status: z.enum([ProductStatus.PENDING, ProductStatus.APPROVED, ProductStatus.REJECTED]).optional(),
 });
 
 export type Product = z.infer<typeof ProductSchema>;


### PR DESCRIPTION
# Fix: Update ProductSchema and Add ProductUses Validation

## Description
This PR addresses two main issues:
1. Updates the ProductSchema to properly handle date fields
2. Enforces proper validation for productUses field which is crucial for chatbot functionality

### Changes Made
1. **Date Field Validation**
   - Modified `createdAt` and `updatedAt` fields in ProductSchema to use `z.string().datetime()` instead of `z.date()`
   - This allows the API to properly validate product creation requests with ISO format date strings
   - Fixes validation errors when creating new products

2. **ProductUses Field Enhancement**
   - Enforced proper validation for the `productUses` field which is an array of predefined use cases
   - Added validation for the following use cases:
     - CASUAL
     - DATES
     - PARTIES
     - OFFICE
     - TRAVEL
     - SPORTS
     - FORMALS
   - This field is crucial for the chatbot's ability to recommend products based on use case

### Impact
- **API Changes**: Product creation endpoint now properly validates date strings and product use cases
- **Chatbot Integration**: The productUses field will be used by the chatbot to:
  - Recommend products based on user's intended use
  - Filter products by occasion/use case
  - Provide more accurate product suggestions
  - Enable context-aware product recommendations

### Example Usage
```json
{
  "title": "Men's Formal Shirt",
  "description": "High-quality formal shirt for men",
  "price": 999.99,
  "category": "MENS",
  "stock": 100,
  "productUses": ["OFFICE", "FORMALS"],
  "discount": 0,
  "createdAt": "2024-02-27T00:00:00.000Z",
  "updatedAt": "2024-02-27T00:00:00.000Z"
}
```

### Testing
- [ ] Verify product creation with valid date strings
- [ ] Verify product creation with valid productUses
- [ ] Verify validation errors for invalid date formats
- [ ] Verify validation errors for invalid productUses
- [ ] Test chatbot integration with the updated productUses field (in future)

### Dependencies
- Requires server restart for schema changes to take effect
- No database migrations needed

by @prakshark 